### PR TITLE
优化 & 逻辑调整

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sibi-title-generator
 
-生成形如《驳《驳《驳《XXXXX》》》》的文章标题
+生成形如《驳<驳<驳<XXXXX>>>》的文章标题
 
 ## Installation
 
@@ -13,9 +13,9 @@ git clone https://github.com/tuobaye0711/sibi-title-generator.git
 ```javascript
 const sibi = require('sibi-title-generator');
 
-sibi('我不是很懂 Node.js 社区的 DRY 文化', 3); // 《驳《驳《我不是很懂 Node.js 社区的 DRY 文化》》》
-sibi('Vue从Angular里面抄了哪些东西？', 5); // 《驳《驳《驳《驳《Vue从Angular里面抄了哪些东西？》》》》》
-sibi('不明真相的围观群众', 0); // 《不明真相的围观群众》
+sibi('我不是很懂 Node.js 社区的 DRY 文化', 3); // 驳《驳<驳<我不是很懂 Node.js 社区的 DRY 文化>>》
+sibi('Vue从Angular里面抄了哪些东西？', 5); // 驳《驳<驳<驳<驳<我不是很懂 Node.js 社区的 DRY 文化>>>>》
+sibi('不明真相的围观群众', 0); // 不明真相的围观群众
 ```
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,6 @@
-const sibiTitleGenerator = (title, n, withSymbol) => {
-    if (!withSymbol) {
-        withSymbol = true
-    }
-    let newTitle = title;
-    n = Math.floor(n);
-    if (n <= 0) {
-        return withSymbol ? `《${newTitle}》` : newTitle
-    }
-    return sibiTitleGenerator(`驳《${newTitle}》`, --n, withSymbol)
+const sibiTitleGenerator = (title, n) => {
+    if (!n) return title;
+    return "驳《" + "驳<".repeat(n - 1) + title + ">".repeat(n - 1) + "》";
 }
+
 module.exports = sibiTitleGenerator;


### PR DESCRIPTION
1. 原代码中使用了递归,当递归次数过多时会调用栈溢出
```JavaScript
const sibi = require('sibi-title-generator');
sibi('我不是很懂 Node.js 社区的 DRY 文化', 9999);
// Uncaught RangeError: Maximum call stack size exceeded
```
2. 书名号中的书名号用"<>"
3. 逻辑做了调整,取消了最外层的书名号

原逻辑:  

```JavaScript
const sibi = require('sibi-title-generator');
sibi('我不是很懂 Node.js 社区的 DRY 文化', 0); // "《我不是很懂 Node.js 社区的 DRY 文化》"
sibi('我不是很懂 Node.js 社区的 DRY 文化', 1); // "《驳《我不是很懂 Node.js 社区的 DRY 文化》》"
sibi('我不是很懂 Node.js 社区的 DRY 文化', 2); // "《驳《驳《我不是很懂 Node.js 社区的 DRY 文化》》》"
```

改过的逻辑  

```JavaScript
const sibi = require('sibi-title-generator');
sibi('我不是很懂 Node.js 社区的 DRY 文化', 0); // "我不是很懂 Node.js 社区的 DRY 文化"
sibi('我不是很懂 Node.js 社区的 DRY 文化', 1); // "驳《我不是很懂 Node.js 社区的 DRY 文化》"
sibi('我不是很懂 Node.js 社区的 DRY 文化', 2); // "驳《驳<我不是很懂 Node.js 社区的 DRY 文化>》"
```

:-)